### PR TITLE
fix build on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+VERSION+=$(shell git log --oneline -n 1 | sed 's/\ .*//')$(shell git status --porcelain | grep -q '^\ M' && echo -n M)
 CC=gcc
-CFLAGS=-Wall -pedantic -g -DUNIX_HOST -DVER=\"`svnversion -n`\"
+CFLAGS=-Wall -pedantic -g -DUNIX_HOST -DVER=\"${VERSION}\"
 LIBS=-lm -lreadline
 
 TARGET	= picoc

--- a/cstdlib/unistd.c
+++ b/cstdlib/unistd.c
@@ -6,6 +6,7 @@
 #include "../interpreter.h"
 
 #ifndef BUILTIN_MINI_STDLIB
+#ifndef _WIN32 /* TODO */
 
 static int ZeroValue = 0;
 
@@ -501,5 +502,5 @@ void UnistdSetupFunc(Picoc *pc)
     VariableDefinePlatformVar(pc, NULL, "optopt", &pc->IntType, (union AnyValue *)&optopt, TRUE);
 }
 
+#endif /* !_WIN32 */
 #endif /* !BUILTIN_MINI_STDLIB */
-


### PR DESCRIPTION
temporary disabled cstdlib/unistd to build on windows. some API may be enabled to implement on windows in future.