### PR TITLE
Create initial .travis.yml file for basic configurations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+compiler: 
+    - gcc
+    - clang
+env:
+    - CFLAGS="-Wall -pedantic -g -DUNIX_HOST"
+    - CFLAGS="-m32 -Wall -pedantic -g -DUNIX_HOST"
+install: 
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq gcc-multilib lib32readline6-dev
+script: make && make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CC=gcc
-CFLAGS=-Wall -pedantic -g -DUNIX_HOST -DVER=\"`svnversion -n`\"
+CC?=gcc
+CFLAGS?=-Wall -pedantic -g -DUNIX_HOST -DVER=\"`svnversion -n`\"
 LIBS=-lm -lreadline
 
 TARGET	= picoc


### PR DESCRIPTION
GCC and CLANG both in 32 and 64 bits mode are built.
Makefile modified so CC and CFLAGS assignation can be overridden.

This should fix #13.