### PR TITLE
Fix issue #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-Wall -pedantic -g -DUNIX_HOST -DVER=\"`svnversion -n`\"
+CFLAGS=-Wall -pedantic -g -DUNIX_HOST
 LIBS=-lm -lreadline
 
 TARGET	= picoc


### PR DESCRIPTION
I had to remove `-DVER=\"svnversion -n\"` from the `Makefile`, otherwise I got this error:

```
gcc -Wall -pedantic -g -DUNIX_HOST -DVER=\"`svnversion -n`\"   -c -o picoc.o picoc.c
gcc: error: directory": No such file or directory
make: *** [picoc.o] Error 1
```
